### PR TITLE
Fix test badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](../../workflows/gds/badge.svg) ![](../../workflows/docs/badge.svg) ![](../../workflows/test.yaml/badge.svg)
+![](../../workflows/gds/badge.svg) ![](../../workflows/docs/badge.svg) ![](../../workflows/test/badge.svg)
 
 # What is Tiny Tapeout?
 


### PR DESCRIPTION
The `.yaml` is not necessary in the README badge.